### PR TITLE
Remove SteamManager call to DontDestroyOnLoad when component is not at root hierarchy.

### DIFF
--- a/Assets/Scripts/Steamworks.NET/SteamManager.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamManager.cs
@@ -76,8 +76,10 @@ public class SteamManager : MonoBehaviour {
 			throw new System.Exception("Tried to Initialize the SteamAPI twice in one session!");
 		}
 
-		// We want our SteamManager Instance to persist across scenes.
-		DontDestroyOnLoad(gameObject);
+		if (transform.parent == null) {
+			// We want our SteamManager Instance to persist across scenes.
+			DontDestroyOnLoad(gameObject);
+		}
 
 		if (!Packsize.Test()) {
 			Debug.LogError("[Steamworks.NET] Packsize Test returned false, the wrong version of Steamworks.NET is being run in this platform.", this);


### PR DESCRIPTION
Fixes: Issue where a freeze on the main thead was occuring in il2cpp when the SteamManager was not at the root of the scene hierachy.

Calling DontDestroyOnLoad on an object that is not at the root of the hierarchy is not handled well by Unity, it generates a freeze on the main thread (specially on il2cpp targets) and a warning.

The fix in this MR does not call DontDestroyOnLoad if the game object is not at the root of the hierarchy to not take any reponsability on other objects. Another way to fix this issue can be to call DontDestroyOnLoad on the parent object (the one at the root of the hierarchy) or to assert that it is impossible to put this script on a child object.